### PR TITLE
Add FastAPI backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cloudfunctions/
+__pycache__/
+*.pyc

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,12 @@
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Application configuration"""
+
+    database_url: str = Field(
+        default="sqlite:///./test.db", env="DATABASE_URL"
+    )
+
+
+settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello, World!"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+sqlmodel


### PR DESCRIPTION
## Summary
- set up FastAPI application with root endpoint
- add configuration using environment variable `DATABASE_URL`
- list FastAPI, Uvicorn, and SQLModel dependencies

## Testing
- `python -m py_compile backend/app/*.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_68afc1403234832c9fa026ad1169fffa